### PR TITLE
Add websocket compiler frontend and self-contained server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Online Compiler
+
+This project includes a small Go server and a responsive web front–end to
+execute short code snippets in Go, Python, PHP and Java. The browser communicates
+with the backend via WebSockets.
+
+## Server API
+
+- `GET /languages` – returns an array of supported languages.
+- `WS /ws` – accepts JSON messages of the form:
+  ```json
+  {"language": "python", "code": "print('hello')"}
+  ```
+  and responds with:
+  ```json
+  {"output": "hello\n", "error": ""}
+  ```
+
+## Front‑end
+
+Open the root page and you will find a simple editor with a language selector,
+a run button and an output area. A theme toggle allows switching between dark
+and light modes. The layout adapts to small screens.
+
+## Running
+
+```
+go run .
+```
+
+Then open `http://localhost:8080/` in your browser.
+
+The build requires only the Go standard library so it works offline.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module ab
+
+go 1.20

--- a/index
+++ b/index
@@ -1,3 +1,0 @@
-Hello
-Salom
-Hello

--- a/main.go
+++ b/main.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+var languages = []string{"go", "python", "php", "java"}
+
+// simple websocket connection handling only text frames
+func wsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Upgrade") != "websocket" {
+		http.Error(w, "upgrade required", http.StatusUpgradeRequired)
+		return
+	}
+	key := r.Header.Get("Sec-WebSocket-Key")
+	if key == "" {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	acceptKey := computeAcceptKey(key)
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	conn, buf, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\n")
+	fmt.Fprintf(buf, "Upgrade: websocket\r\n")
+	fmt.Fprintf(buf, "Connection: Upgrade\r\n")
+	fmt.Fprintf(buf, "Sec-WebSocket-Accept: %s\r\n\r\n", acceptKey)
+	buf.Flush()
+
+	for {
+		payload, err := readFrame(buf)
+		if err != nil {
+			if err != io.EOF {
+				log.Println("read:", err)
+			}
+			break
+		}
+		var req ExecRequest
+		if err := json.Unmarshal(payload, &req); err != nil {
+			log.Println("bad json:", err)
+			continue
+		}
+		resp := execCode(req)
+		data, _ := json.Marshal(resp)
+		if err := writeFrame(buf, data); err != nil {
+			log.Println("write:", err)
+			break
+		}
+	}
+}
+
+func computeAcceptKey(key string) string {
+	h := sha1.Sum([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(h[:])
+}
+
+func readFrame(r *bufio.ReadWriter) ([]byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, err
+	}
+	masked := header[1]&0x80 != 0
+	length := int(header[1] & 0x7F)
+	switch length {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return nil, err
+		}
+		length = int(binary.BigEndian.Uint16(ext))
+	case 127:
+		ext := make([]byte, 8)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return nil, err
+		}
+		length = int(binary.BigEndian.Uint64(ext))
+	}
+	var maskKey [4]byte
+	if masked {
+		if _, err := io.ReadFull(r, maskKey[:]); err != nil {
+			return nil, err
+		}
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	if masked {
+		for i := 0; i < length; i++ {
+			payload[i] ^= maskKey[i%4]
+		}
+	}
+	return payload, nil
+}
+
+func writeFrame(w *bufio.ReadWriter, payload []byte) error {
+	w.WriteByte(0x81) // FIN + text frame
+	if len(payload) < 126 {
+		w.WriteByte(byte(len(payload)))
+	} else if len(payload) < 65536 {
+		w.WriteByte(126)
+		var buf [2]byte
+		binary.BigEndian.PutUint16(buf[:], uint16(len(payload)))
+		w.Write(buf[:])
+	} else {
+		w.WriteByte(127)
+		var buf8 [8]byte
+		binary.BigEndian.PutUint64(buf8[:], uint64(len(payload)))
+		w.Write(buf8[:])
+	}
+	w.Write(payload)
+	return w.Flush()
+}
+
+func languagesHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(languages)
+}
+
+type ExecRequest struct {
+	Language string `json:"language"`
+	Code     string `json:"code"`
+}
+
+type ExecResponse struct {
+	Output string `json:"output,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func execCode(req ExecRequest) ExecResponse {
+	switch req.Language {
+	case "go":
+		return execGo(req.Code)
+	case "python":
+		return execCommand("python3", "-c", req.Code)
+	case "php":
+		return execCommand("php", "-r", req.Code)
+	case "java":
+		return execJava(req.Code)
+	default:
+		return ExecResponse{Error: "unsupported language"}
+	}
+}
+
+func execCommand(name string, args ...string) ExecResponse {
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ExecResponse{Output: string(output), Error: err.Error()}
+	}
+	return ExecResponse{Output: string(output)}
+}
+
+func execGo(code string) ExecResponse {
+	tmpDir, err := ioutil.TempDir("", "gocode")
+	if err != nil {
+		return ExecResponse{Error: err.Error()}
+	}
+	defer os.RemoveAll(tmpDir)
+
+	path := tmpDir + "/main.go"
+	if err := ioutil.WriteFile(path, []byte(code), 0644); err != nil {
+		return ExecResponse{Error: err.Error()}
+	}
+
+	cmd := exec.Command("go", "run", path)
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ExecResponse{Output: string(output), Error: err.Error()}
+	}
+	return ExecResponse{Output: string(output)}
+}
+
+func execJava(code string) ExecResponse {
+	tmpDir, err := ioutil.TempDir("", "javacode")
+	if err != nil {
+		return ExecResponse{Error: err.Error()}
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcPath := tmpDir + "/Main.java"
+	if err := ioutil.WriteFile(srcPath, []byte(code), 0644); err != nil {
+		return ExecResponse{Error: err.Error()}
+	}
+
+	cmd := exec.Command("javac", "Main.java")
+	cmd.Dir = tmpDir
+	outCompile, err := cmd.CombinedOutput()
+	if err != nil {
+		return ExecResponse{Output: string(outCompile), Error: err.Error()}
+	}
+
+	cmd = exec.Command("java", "Main")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ExecResponse{Output: string(output), Error: err.Error()}
+	}
+	return ExecResponse{Output: string(output)}
+}
+
+func main() {
+	http.HandleFunc("/languages", languagesHandler)
+	http.HandleFunc("/ws", wsHandler)
+	http.Handle("/", http.FileServer(http.Dir("public")))
+	fmt.Println("Server running on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Online Compiler</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+<header>
+<h1>Online Compiler</h1>
+<button id="theme-toggle">Toggle Theme</button>
+</header>
+<div class="controls">
+<select id="language"></select>
+<button id="run">Run</button>
+</div>
+<textarea id="code" class="editor" placeholder="Enter code here..."></textarea>
+<pre id="output" class="output"></pre>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,43 @@
+const themeToggle = document.getElementById('theme-toggle');
+const root = document.documentElement;
+
+function setTheme(theme) {
+  if (theme === 'dark') {
+    root.setAttribute('data-theme', 'dark');
+  } else if (theme === 'light') {
+    root.setAttribute('data-theme', 'light');
+  } else {
+    root.removeAttribute('data-theme');
+  }
+  localStorage.setItem('theme', theme);
+}
+
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme) setTheme(savedTheme);
+
+themeToggle.addEventListener('click', () => {
+  const current = root.getAttribute('data-theme');
+  setTheme(current === 'dark' ? 'light' : 'dark');
+});
+
+const languageSelect = document.getElementById('language');
+fetch('/languages').then(r => r.json()).then(langs => {
+  langs.forEach(l => {
+    const opt = document.createElement('option');
+    opt.value = l; opt.textContent = l; languageSelect.appendChild(opt);
+  });
+});
+
+const ws = new WebSocket(`ws://${location.host}/ws`);
+ws.onmessage = ev => {
+  const resp = JSON.parse(ev.data);
+  document.getElementById('output').textContent = resp.output || resp.error || '';
+};
+
+document.getElementById('run').addEventListener('click', () => {
+  const req = {
+    language: languageSelect.value,
+    code: document.getElementById('code').value
+  };
+  ws.send(JSON.stringify(req));
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,69 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #222222;
+  --control-bg: #f0f0f0;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1e1e1e;
+  --text-color: #f5f5f5;
+  --control-bg: #2e2e2e;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.editor {
+  width: 100%;
+  height: 200px;
+  font-family: monospace;
+  border: 1px solid #ccc;
+  background-color: var(--control-bg);
+  color: var(--text-color);
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+.output {
+  background-color: var(--control-bg);
+  padding: 0.5rem;
+  min-height: 100px;
+  white-space: pre-wrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-color: #1e1e1e;
+    --text-color: #f5f5f5;
+    --control-bg: #2e2e2e;
+  }
+}
+
+@media (max-width: 600px) {
+  .editor {
+    height: 150px;
+  }
+}


### PR DESCRIPTION
## Summary
- remove gorilla/websocket dependency and implement minimal websocket handling
- add responsive frontend with dark/light modes
- serve static files and update documentation

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a9f0a070483259480d5eb802a3a82